### PR TITLE
Adding work product pages

### DIFF
--- a/pages/news/2017-08-01-midterm/index.md
+++ b/pages/news/2017-08-01-midterm/index.md
@@ -15,7 +15,7 @@ tags:
 Probably the most essential part of Green Navigation is the routing server. Amongst other things, the routing server should be able to account for weather and height differences, and collaborate closely with our database project. Our project requires a fast and reliable server that supports computational optimal routing using efficient algorithms. Our student Pavel so far already has implemented the routing application via Dijkstra and AStar algorithms that supports navigating from point to point via a provided persistence interface. Currently, he is working on a prototype of contraction hierarchies and an API for visualization. 
 
 # Leah Chrestien: Range Anxiety  
-**Category:** Frontend  
+**Category:** Algorithm  
 **Mentors:** Bruno Magalhaes, René Schönfelder
 
 Since recharging an electric vehicle takes longer than refueling a combustion engine vehicle, a lot of (potential) customers of electric vehicles have a fear of running out of energy. One step towards the solution is a precise computation and visualization of the vehicle’s range. Leah’s project aims to provide a well sketched road map that can safely determine the distances up to which the vehicle can travel without having to recharge in the midst of its on-going journey. Instead of using a circle to form the range boundary, Leah is using a polygon. And what is even better than one polygon? Two polygons! One describing the places that the electric vehicles can reach and another one describing the places the vehicle can reach AND return home from, which is approximately half as big. This is so because of the differences in energy consumption in different areas (like mountainous areas, for instance). This is how Leah determines the nodes forming the range boundary: 
@@ -23,9 +23,10 @@ Since recharging an electric vehicle takes longer than refueling a combustion en
 First of all, all the coordinates forming nodes are assigned a unique key, which acts as an identifier. Then, a starting location is chosen, based on which the range will be determined. The haversine formula is used to determine the geographic
 distance between any two coordinates and at any step, the haversine function is called with four input parameters (latitude 1, longitude 1, latitude 2, longitude 2) and returns the geographic distance between the coordinates - the value of range is set. 
 This enables the algorithm to select nodes at that particular distance from the chosen centre. The algorithm uses the haversine function to determine these edge nodes, which are the filtered nodes. A double dimension array is introduced at this stage to store the distances between all the filtered nodes. To achieve a polygon having the minimum number of intersecting edges, it is important to output the coordinates in an ordered manner. Here, the travelling salesman problem (using nearest neighbour approach) is implemented to ensure minimum distances between all the filtered nodes. This problem is NP-hard and there is still a finite possibility of the intersection of edges. One can decrease this possibility by increasing the filtered nodes (and therefore increasing the original number of nodes) and improving the range precision. The output from this step is an ordered set of filtered nodes. The ordered set of filtered nodes from the last step is shown an a geoJSON output, which can be readily used in any map editor.
-Jia Rui Ong: Smart Range Viewer
-Category: Frontend
-Mentor: Franz Klaus
+
+# Jia Rui Ong: Smart Range Viewer
+**Category:** Frontend  
+**Mentors:** Franz Klaus, Thomas Ort
 
 In addition to that, Jia is working on the smart range viewer project, which involves building a range computation visualization tool on top of the react application to ease range anxiety among electric vehicle drivers. Some of the tasks he has completed so far include:
 the addition of input fields to the reachability tab, 
@@ -40,7 +41,7 @@ This is what it looks like at the moment:
 
 ![screenshot](https://user-images.githubusercontent.com/25430929/28843971-6f39fb52-7703-11e7-8c1b-b880176dc697.png)
 
-# Samya Suvarna: Traffic Avoidance  
+# Saumya Suvarna: Traffic Avoidance  
 **Category:** Experimental  
 **Mentors:** Fabian Bormann
 

--- a/pages/news/2017-08-23-gsoc2017-predicting-energy-consumption-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-predicting-energy-consumption-wp/index.md
@@ -1,0 +1,33 @@
+---
+title: GSoC 2017 - Predicting Energy Consumption - Indraneil Paul
+date: '2017-08-23T00:00:00.284Z'
+layout: post
+path: /news/2017-08-23-gsoc2017-predicting-energy-consumption-wp/
+tags:
+  - google
+  - gsoc
+---
+
+### Google Summer of Code 2017
+### Implementation of Predicting Energy Consumption, by Indraneil Paul
+
+**Category:** Experimental  
+**Mentors:** Florian Lenschow
+
+## Overview
+
+This post is about my GSoC project, under Greennav organization, on the implementation of Predicting Energy Consumption.
+
+### Proposal link
+
+[Prediction of Energy Consumption of Electric Vehicles](https://summerofcode.withgoogle.com/serve/4838044573106176/)
+
+## Final Product
+
+  * #### Repository
+
+  * #### Commits
+
+  * #### [Kanban Board](https://github.com/orgs/Greennav/projects/6)
+
+## What's left to do

--- a/pages/news/2017-08-23-gsoc2017-range-anxiety-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-range-anxiety-wp/index.md
@@ -26,7 +26,7 @@ This post is about my GSoC project, under Greennav organization, implementing Ra
 
   * #### [Repository](https://github.com/Greennav/range-anxiety)
 
-  * #### [Commits](https://github.com/Greennav/range-anxiety)
+  * #### [Commits](https://github.com/Greennav/range-anxiety/commits/master)
 
   * #### [Kanban Board](https://github.com/orgs/Greennav/projects/2)
 

--- a/pages/news/2017-08-23-gsoc2017-range-anxiety-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-range-anxiety-wp/index.md
@@ -1,0 +1,41 @@
+---
+title: GSoC 2017 - Range Anxiety - Leah Chrestien
+date: '2017-08-23T00:00:00.284Z'
+layout: post
+path: /news/2017-08-23-gsoc2017-range-anxiety-wp/
+tags:
+  - google
+  - gsoc
+---
+
+### Google Summer of Code 2017
+### Implementing Range Anxiety, by Leah Chrestien
+
+**Category:** Algorithm  
+**Mentors:** Bruno Magalhaes, René Schönfelder
+
+## Overview
+
+This post is about my GSoC project, under Greennav organization, implementing Range Anxiety algorithms.
+
+### Proposal link
+
+[A Medication for e-range anxiety](https://summerofcode.withgoogle.com/serve/4562469270847488/)
+
+## Final Product
+
+  * #### [Repository](https://github.com/Greennav/range-anxiety)
+
+  * #### [Commits](https://github.com/Greennav/range-anxiety)
+
+  * #### [Kanban Board](https://github.com/orgs/Greennav/projects/2)
+
+## Reports
+
+  * [Objectives of the Range Anxiety project](https://github.com/Greennav/range-anxiety/blob/master/docs/report1.pdf)
+  * [Algorithm summary, Travelling Salesman](https://github.com/Greennav/range-anxiety/blob/master/docs/report2.pdf)
+  * [Results: GeoJSON output and polygon](https://github.com/Greennav/range-anxiety/blob/master/docs/results1.pdf)
+  * [Results: API Demonstration](https://github.com/Greennav/range-anxiety/blob/master/docs/results2.pdf)
+  * [Algorithm Performance and Time Complexity](https://github.com/Greennav/range-anxiety/blob/master/docs/FinalReport.pdf)
+
+## What's left to do

--- a/pages/news/2017-08-23-gsoc2017-routing-server-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-routing-server-wp/index.md
@@ -1,0 +1,33 @@
+---
+title: GSoC 2017 - Pavel Danilov - The Routing Server
+date: '2017-08-23T00:00:00.284Z'
+layout: post
+path: /news/2017-08-23-gsoc2017-routing-server-wp/
+tags:
+  - google
+  - gsoc
+---
+
+### Google Summer of Code 2017
+### Implementing The Routing Server, by Pavel Danilov
+
+**Category:** Backend  
+**Mentors:** Sebastian Bode
+
+## Overview
+
+This post is about my GSoC project, under Greennav organization, implementing the Routing Server.
+
+### Proposal link
+
+[Routing server](https://summerofcode.withgoogle.com/serve/5836956255649792/)
+
+## Final Product
+
+  * #### [Repository](https://github.com/Greennav/routing) [fork](https://github.com/Carix0n/routing)
+
+  * #### [Commits](https://github.com/Greennav/routing/commits/master)
+
+  * #### [Kanban Board](https://github.com/orgs/Greennav/projects/4)
+
+## What's left to do

--- a/pages/news/2017-08-23-gsoc2017-routing-server-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-routing-server-wp/index.md
@@ -1,5 +1,5 @@
 ---
-title: GSoC 2017 - Pavel Danilov - The Routing Server
+title: GSoC 2017 - The Routing Server - Pavel Danilov
 date: '2017-08-23T00:00:00.284Z'
 layout: post
 path: /news/2017-08-23-gsoc2017-routing-server-wp/

--- a/pages/news/2017-08-23-gsoc2017-routing-server-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-routing-server-wp/index.md
@@ -24,7 +24,7 @@ This post is about my GSoC project, under Greennav organization, implementing th
 
 ## Final Product
 
-  * #### [Repository](https://github.com/Greennav/routing) [fork](https://github.com/Carix0n/routing)
+  * #### [Repository](https://github.com/Greennav/routing) (dev fork: [Routing](https://github.com/Carix0n/routing))
 
   * #### [Commits](https://github.com/Greennav/routing/commits/master)
 

--- a/pages/news/2017-08-23-gsoc2017-smart-range-viewer-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-smart-range-viewer-wp/index.md
@@ -24,7 +24,7 @@ This post is about my GSoC project, under Greennav organization, implementing Sm
 
 ## Final Product
 
-  * #### [Repository](https://github.com/Greennav/GreenNav) [Reachibility](https://github.com/jrios6/GreenNav/tree/reachability)
+  * #### [Repository](https://github.com/Greennav/GreenNav) (dev fork: [Reachibility](https://github.com/jrios6/GreenNav/tree/reachability))
 
   * #### [Commits](https://github.com/jrios6/GreenNav/commits/reachability)
 

--- a/pages/news/2017-08-23-gsoc2017-smart-range-viewer-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-smart-range-viewer-wp/index.md
@@ -1,0 +1,33 @@
+---
+title: GSoC 2017 - Smart Range Viewer - Jia Rui Ong
+date: '2017-08-23T00:00:00.284Z'
+layout: post
+path: /news/2017-08-23-gsoc2017-smart-range-viewer-wp/
+tags:
+  - google
+  - gsoc
+---
+
+### Google Summer of Code 2017
+### Implementing Smart Range Viewer, by Jia Rui Ong
+
+**Category:** Frontend  
+**Mentors:** Franz Klaus
+
+## Overview
+
+This post is about my GSoC project, under Greennav organization, implementing Smart Range Viewer.
+
+### Proposal link
+
+[Smart Range Viewer](https://summerofcode.withgoogle.com/dashboard/project/5565023555420160/overview/)
+
+## Final Product
+
+  * #### [Repository](https://github.com/Greennav/GreenNav) [Reachibility](https://github.com/jrios6/GreenNav/tree/reachability)
+
+  * #### [Commits](https://github.com/jrios6/GreenNav/commits/reachability)
+
+  * #### [Kanban Board](https://github.com/orgs/Greennav/projects/1)
+
+## What's left to do

--- a/pages/news/2017-08-23-gsoc2017-smart-range-viewer-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-smart-range-viewer-wp/index.md
@@ -20,7 +20,7 @@ This post is about my GSoC project, under Greennav organization, implementing Sm
 
 ### Proposal link
 
-[Smart Range Viewer](https://summerofcode.withgoogle.com/dashboard/project/5565023555420160/overview/)
+[Smart Range Viewer](https://summerofcode.withgoogle.com/serve/5186012622880768/)
 
 ## Final Product
 

--- a/pages/news/2017-08-23-gsoc2017-smart-range-viewer-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-smart-range-viewer-wp/index.md
@@ -12,7 +12,7 @@ tags:
 ### Implementing Smart Range Viewer, by Jia Rui Ong
 
 **Category:** Frontend  
-**Mentors:** Franz Klaus
+**Mentors:** Franz Klaus, Thomas Ort
 
 ## Overview
 

--- a/pages/news/2017-08-23-gsoc2017-traffic-avoidance-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-traffic-avoidance-wp/index.md
@@ -1,0 +1,33 @@
+---
+title: GSoC 2017 - Traffic Avoidance - Samya Suvarna
+date: '2017-08-23T00:00:00.284Z'
+layout: post
+path: /news/2017-08-23-gsoc2017-traffic-avoidance-wp/
+tags:
+  - google
+  - gsoc
+---
+
+### Google Summer of Code 2017
+### Implementing Traffic Avoidance, by Samya Suvarna
+
+**Category:** Experimental  
+**Mentors:** Fabian Bormann
+
+## Overview
+
+This post is about my GSoC project, under Greennav organization, implementing Traffic Avoidance.
+
+### Proposal link
+
+[Traffic avoidance and prediction of energy consumption of electric vehicles with real time notification system](https://summerofcode.withgoogle.com/serve/4528822631268352/)
+
+## Final Product
+
+  * #### [Repository](https://github.com/Greennav/machine-learning)
+
+  * #### [Commits](https://github.com/Greennav/machine-learning/commits/master)
+
+  * #### [Kanban Board](https://github.com/orgs/Greennav/projects/5)
+
+## What's left to do

--- a/pages/news/2017-08-23-gsoc2017-traffic-avoidance-wp/index.md
+++ b/pages/news/2017-08-23-gsoc2017-traffic-avoidance-wp/index.md
@@ -1,5 +1,5 @@
 ---
-title: GSoC 2017 - Traffic Avoidance - Samya Suvarna
+title: GSoC 2017 - Traffic Avoidance - Saumya Suvarna
 date: '2017-08-23T00:00:00.284Z'
 layout: post
 path: /news/2017-08-23-gsoc2017-traffic-avoidance-wp/
@@ -9,7 +9,7 @@ tags:
 ---
 
 ### Google Summer of Code 2017
-### Implementing Traffic Avoidance, by Samya Suvarna
+### Implementing Traffic Avoidance, by Saumya Suvarna
 
 **Category:** Experimental  
 **Mentors:** Fabian Bormann


### PR DESCRIPTION
Added individual work product pages for each student in the news section.

Students will need to fill in the missing parts, namely overview and what's left sections, and also verify the links are correct. 

They're also free to add sections that complement their work, for example add diagrams or screenshots of the final product.

Once merged, the blog post can be used as final Work Product link in the GSoC evaluation.